### PR TITLE
Improve support for Cray OpenMP runtime and device tracing interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,24 @@ After building the library, the tool can be used with the environment variable
 `OMP_TOOL_LIBRARIES`. Please note that NVHPC requires adding `-mp=ompt` when building
 a program since this affects code generation and the linked OpenMP library.
 
+## Controlling the tool
+
+`ompt-printf` implements the `ompt_callback_control_tool` callback using the default commands
+specified in the OpenMP standard. An application can use `omp_control_tool` to control the
+device tracing interface with the following options:
+
+| Command                  | Modifier                            | Effect                                            |
+|--------------------------|-------------------------------------|---------------------------------------------------|
+| `omp_control_tool_start` | (ignored)                           | Starts device tracing on all initialized devices. |
+| `omp_control_tool_flush` | (ignored)                           | Flushes all device tracing buffers.               |
+| `omp_control_tool_pause` | `true` to pause, `false` to unpause | Pauses device tracing on all initialized devices. |
+| `omp_control_tool_end`   | (ignored)                           | Stops device tracing on all initialized devices.  |
+
+These options will only affect devices which have been fully initialized and support the device tracing interface.
+The remainder of the tool will not be affected by these commands.
+
+## Example
+
 Here is an example on building a program with the tool enabled (Clang 17.0.6, Arch Linux):
 ```bash
 $ cat my-openmp-example.c

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -1946,9 +1946,10 @@ callback_device_finalize( int device_num )
     {
         if constexpr ( mode > printf_mode::disable_output )
         {
-            atomic_printf( "[%s] Device %d not found. "
+            atomic_printf( "[%s] Device %d not found. Number of devices: %d. "
                            "The runtime may have already cleaned up some state. Skip flushing buffers.\n",
                            __FUNCTION__,
+                           devices.size(),
                            device_num );
         }
         return;

--- a/src/tool.cpp
+++ b/src/tool.cpp
@@ -549,7 +549,7 @@ work2string( ompt_work_t t )
         case ompt_work_loop_static:
             return "loop_static";
         #endif
-        #if HAVE( OMPT_WORK_LOOP_DYTNAMIC )
+        #if HAVE( OMPT_WORK_LOOP_DYNAMIC )
         case ompt_work_loop_dynamic:
             return "loop_dynamic";
         #endif


### PR DESCRIPTION
- Make implementation of interface less strict so that Cray compilers are correctly checked.
- Do not fail when `ompt_callback_device_finalize` is dispatched after state was cleaned-up already.
- Implement `ompt_control_tool` callback to let users control device tracing. Needed for Cray CCE 17.0.1 to dispatch buffers when wanted.