### PR TITLE
Update CI to run for openmp-60

### DIFF
--- a/.github/workflows/build-multiplatform.yml
+++ b/.github/workflows/build-multiplatform.yml
@@ -36,9 +36,9 @@ name: Test on multiple compiler and OS platforms
 
 on:
     push:
-        branches: [ "main", "openmp-52", "openmp-tr13" ]
+        branches: [ "main", "openmp-52", "openmp-60" ]
     pull_request:
-        branches: [ "main", "openmp-52", "openmp-tr13" ]
+        branches: [ "main", "openmp-52", "openmp-60" ]
 
 jobs:
     job_ubuntu-24-clang:


### PR DESCRIPTION
CI was targeting `openmp-tr13`, which was since renamed to `openmp-60`